### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,25 +6,20 @@ edition = "2018"
 
 
 [dependencies.stm32l0xx-hal]
-version  = "0.2.0"
+version  = "0.3.1"
 features = ["rt", "stm32l082"]
 
 [dev-dependencies]
 cortex-m    = "0.6.1"
 cortex-m-rt = "0.6.10"
 panic-halt  = "0.2.0"
-usb-device  = "0.2.2"
+usb-device  = "0.2.3"
 usbd-serial = "0.1.0"
 
 [dev-dependencies.stm32-usbd]
-version  = "0.3.1"
+git      = "https://github.com/stm32-rs/stm32-usbd.git"
+rev      = "67447c6391d93631d9eda6e364d5d465fd6a9222"
 features = ["stm32l0x2xx"]
-
-
-# Required because stm32-usbd depends on the latest crates.io version, while the
-# examples in this repository depend on unreleased features.
-[patch.crates-io.stm32l0xx-hal]
-git = "https://github.com/stm32-rs/stm32l0xx-hal.git"
 
 
 [profile.release]

--- a/examples/exti_wakeup.rs
+++ b/examples/exti_wakeup.rs
@@ -29,7 +29,6 @@ fn main() -> ! {
     let mut exti   = dp.EXTI;
     let mut pwr    = PWR::new(dp.PWR, &mut rcc);
     let mut delay  = cp.SYST.delay(rcc.clocks);
-    let mut nvic   = cp.NVIC;
     let mut scb    = cp.SCB;
     let mut syscfg = SYSCFG::new(dp.SYSCFG_COMP, &mut rcc);
 
@@ -56,7 +55,6 @@ fn main() -> ! {
                     ultra_low_power: true,
                 },
             ),
-            &mut nvic,
         );
 
         led.set_low().unwrap();

--- a/examples/rtc_wakeup.rs
+++ b/examples/rtc_wakeup.rs
@@ -37,7 +37,6 @@ fn main() -> ! {
     // Enable LED to signal that MCU is running
     led.set_low().unwrap();
 
-    let mut nvic   = cp.NVIC;
     let mut scb    = cp.SCB;
     let mut exti   = dp.EXTI;
     let mut pwr    = PWR::new(dp.PWR, &mut rcc);
@@ -79,7 +78,6 @@ fn main() -> ! {
     exti.wait_for_irq(
         exti_line,
         pwr.standby_mode(&mut scb),
-        &mut nvic,
     );
 
     // Waking up from Standby mode resets the microcontroller, so we should


### PR DESCRIPTION
Unfortunately the latest released version of `stm32-usbd` still uses
`stm32l0xx-hal` version 0.2.0, so I've added a Git dependency. This is
not ideal, but more robust than what we had before, as I got rid of the
`[patch]` and added an explicit revision.

cc @lthiery